### PR TITLE
Adding reset password

### DIFF
--- a/src/api/user/service.js
+++ b/src/api/user/service.js
@@ -18,7 +18,7 @@ export class UserService {
   }
 
   /**
-   * Sent when user has forgotten their password
+   * When a user has forgotten their password
    * and asks for a new.
    */
   forgotPassword(email) {
@@ -26,10 +26,10 @@ export class UserService {
   }
 
   /**
-   * Sent when user sets the new password.
+   * When user sets the new password.
    */
   resetPassword(nounce, password) {
-    return axios.post(`backend://dontknowwhichaddress/?nounce=${nounce}&password=${password}`);
+    return axios.post('backend://set-new-password/', { nounce, password });
   }
 
   logout() {

--- a/src/api/user/service.js
+++ b/src/api/user/service.js
@@ -17,8 +17,19 @@ export class UserService {
     return this.currentUser;
   }
 
-  resetPassword(email) {
+  /**
+   * Sent when user has forgotten their password
+   * and asks for a new.
+   */
+  forgotPassword(email) {
     return axios.post(`backend://users/${email}/reset-password`);
+  }
+
+  /**
+   * Sent when user sets the new password.
+   */
+  resetPassword(nounce, password) {
+    return axios.post(`backend://dontknowwhichaddress/?nounce=${nounce}&password=${password}`);
   }
 
   logout() {

--- a/src/components/forms/forgot-password-form/forgot-password-form.js
+++ b/src/components/forms/forgot-password-form/forgot-password-form.js
@@ -27,11 +27,14 @@ const ForgotPasswordReduxForm = (props) => {
       <Image centered size='large' src='/assets/images/logo.png'/>
       <Segment stacked>
         <Form onSubmit={handleSubmit(onSubmit)}>
-          <Header as='h3'>Reset your password</Header>
+          <Header as='h3'>Request a new password</Header>
+          <p className='form-description'>
+            Enter your e-mail address and receive an e-mail that instructs you how to select a new password.
+          </p>
           <Field
             name='email'
             component={Input}
-            placeholder='E-mail'
+            placeholder='Enter your e-mail address'
             icon='users'
             type='email'
             iconposition='left'/>
@@ -40,7 +43,7 @@ const ForgotPasswordReduxForm = (props) => {
             color='blue'
             fluid size='large'
             loading={submitting}>
-              Reset password
+              Submit
           </Button>
           <Message
             error

--- a/src/components/forms/forgot-password-form/style/forgot-password-form.scss
+++ b/src/components/forms/forgot-password-form/style/forgot-password-form.scss
@@ -1,0 +1,3 @@
+.form-description {
+  text-align: left !important;
+}

--- a/src/components/forms/index.js
+++ b/src/components/forms/index.js
@@ -2,3 +2,4 @@ export { LoginForm } from './login-form/login-form';
 export { ForgotPasswordForm } from './forgot-password-form/forgot-password-form';
 export { renderInput as Input } from './input/input';
 export { CreateResellersForm } from './create-reseller-form/create-reseller-form';
+export { ResetPasswordForm } from './reset-password-form/reset-password-form';

--- a/src/components/forms/reset-password-form/reset-password-form.js
+++ b/src/components/forms/reset-password-form/reset-password-form.js
@@ -42,14 +42,14 @@ const ResetPasswordReduxForm = (props) => {
           <Field
             name='password'
             component={Input}
-            placeholder='Password'
+            placeholder='New password'
             icon='users' // todo
             type='password'
             iconposition='left'/>
           <Field
             name='confirmPassword'
             component={Input}
-            placeholder='Enter you password again'
+            placeholder='Enter your new password again'
             icon='users' // todo
             type='password'
             iconposition='left'/>

--- a/src/components/forms/reset-password-form/reset-password-form.js
+++ b/src/components/forms/reset-password-form/reset-password-form.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Button, Form, Header, Image, Message, Segment } from 'semantic-ui-react';
+import { Input } from 'components/forms';
+import { reduxForm, Field } from 'redux-form';
+import { FORM_ERROR_REQUIRED_FIELD } from 'components/forms/errors';
+import { isValidPassword } from '../utils';
+
+const validate = ({ password, confirmPassword }, props) => {
+  let errors = {};
+
+  if (!password) {
+    errors.password = FORM_ERROR_REQUIRED_FIELD;
+  }
+  if (!confirmPassword) {
+    errors.confirmPassword = FORM_ERROR_REQUIRED_FIELD;
+  }
+  if (Object.values(errors).length > 0) {
+    return errors;
+  }
+
+  if (!isValidPassword(password)) {
+    errors.password = 'Password must be at least 5 characters';
+  }
+  if (password !== confirmPassword) {
+    errors.confirmPassword = "The passwords don't match";
+  }
+
+  return errors;
+};
+
+const ResetPasswordReduxForm = (props) => {
+  const { submitting, onSubmit, handleSubmit, error } = props;
+
+  return (
+    <div>
+      <Image centered size='large' src='/assets/images/logo.png'/>
+      <Segment stacked>
+        <Form onSubmit={handleSubmit(onSubmit)}>
+          <Header as='h3'>Reset your password</Header>
+          <Field
+            name='password'
+            component={Input}
+            placeholder='Password'
+            icon='users' // todo
+            type='password'
+            iconposition='left'/>
+          <Field
+            name='confirmPassword'
+            component={Input}
+            placeholder='Enter you password again'
+            icon='users' // todo
+            type='password'
+            iconposition='left'/>
+          <Button
+            type='submit'
+            color='blue'
+            fluid size='large'
+            loading={submitting}>
+              Reset password
+          </Button>
+          <Message
+            error
+            visible={!!error}
+            content={error ? error._error : null}/>
+        </Form>
+        <Message>
+          <Link to='/login'>Back to Login</Link>
+        </Message>
+      </Segment>
+    </div>
+  );
+};
+
+export const ResetPasswordForm = reduxForm({
+  form: 'reset-password-form',
+  fields: ['password', 'confirmPassword'],
+  validate
+})(ResetPasswordReduxForm);
+
+ResetPasswordReduxForm.propTypes = {
+  onSubmit: PropTypes.func,
+  handleSubmit: PropTypes.func,
+  error: PropTypes.object,
+  submitting: PropTypes.bool
+};

--- a/src/components/forms/reset-password-form/reset-password-form.js
+++ b/src/components/forms/reset-password-form/reset-password-form.js
@@ -38,7 +38,7 @@ const ResetPasswordReduxForm = (props) => {
       <Image centered size='large' src='/assets/images/logo.png'/>
       <Segment stacked>
         <Form onSubmit={handleSubmit(onSubmit)}>
-          <Header as='h3'>Reset your password</Header>
+          <Header as='h3'>Enter new password</Header>
           <Field
             name='password'
             component={Input}
@@ -58,7 +58,7 @@ const ResetPasswordReduxForm = (props) => {
             color='blue'
             fluid size='large'
             loading={submitting}>
-              Reset password
+              Update password
           </Button>
           <Message
             error
@@ -66,7 +66,7 @@ const ResetPasswordReduxForm = (props) => {
             content={error ? error._error : null}/>
         </Form>
         <Message>
-          <Link to='/login'>Back to Login</Link>
+          <Link to='/login'>To Login</Link>
         </Message>
       </Segment>
     </div>

--- a/src/components/forms/reset-password-form/reset-password-form.js
+++ b/src/components/forms/reset-password-form/reset-password-form.js
@@ -43,14 +43,14 @@ const ResetPasswordReduxForm = (props) => {
             name='password'
             component={Input}
             placeholder='New password'
-            icon='users' // todo
+            icon='lock'
             type='password'
             iconposition='left'/>
           <Field
             name='confirmPassword'
             component={Input}
             placeholder='Enter your new password again'
-            icon='users' // todo
+            icon='lock'
             type='password'
             iconposition='left'/>
           <Button

--- a/src/components/forms/utils.js
+++ b/src/components/forms/utils.js
@@ -1,2 +1,5 @@
 export const isValidEmail = (email) =>
   /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email);
+
+export const isValidPassword = (password) =>
+  password && password.length >= 5;

--- a/src/routes/forgot-password/forgot-password-container.js
+++ b/src/routes/forgot-password/forgot-password-container.js
@@ -9,8 +9,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = dispatch => ({
   push: (path) => dispatch(push(path)),
-  openModal: (header, content) =>
-    dispatch(openModal(header, content))
+  openModal: (header, content) => dispatch(openModal(header, content))
 });
 
 export const ForgotPasswordContainer =

--- a/src/routes/forgot-password/forgot-password.js
+++ b/src/routes/forgot-password/forgot-password.js
@@ -16,7 +16,8 @@ export class ForgotPassword extends Component {
       // note, handle error with modal
       .catch((e) => {
         this.props.openModal({
-          header: 'Reset password failed!'
+          header: 'Request failed!',
+          content: 'Failed to request new password.'
         });
       });
   }

--- a/src/routes/forgot-password/forgot-password.js
+++ b/src/routes/forgot-password/forgot-password.js
@@ -11,7 +11,7 @@ export class ForgotPassword extends Component {
   };
 
   onSubmit = (values) => {
-    return userService.resetPassword(values.email)
+    return userService.forgotPassword(values.email)
       .then(() => this.props.push('login'))
       // note, handle error with modal
       .catch((e) => {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,6 +3,7 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 import { CoreLayout } from '../layouts/core-layout/core-layout';
 import { LoginContainer } from './login/login-container';
 import { ForgotPasswordContainer } from './forgot-password/forgot-password-container';
+import { ResetPasswordContainer } from './reset-password/reset-password-container';
 import { Dashboard } from './dashboard/dashboard';
 import { requiresAuthentication } from './utils';
 import { RoutingNavbar } from 'components';
@@ -15,6 +16,7 @@ export const createRoutes = () => {
         <Route exact path='/' component={LoginContainer}/>
         <Route exact path='/login' component={LoginContainer}/>
         <Route exact path='/forgot-password' component={ForgotPasswordContainer}/>
+        <Route exact path='/reset-password/:nounce' component={ResetPasswordContainer}/>
         <RoutingNavbar>
           <Switch>
             <Route exact path='/dashboard' component={requiresAuthentication(Dashboard)}/>

--- a/src/routes/login/login-container.js
+++ b/src/routes/login/login-container.js
@@ -11,8 +11,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = dispatch => ({
   push: (path) => dispatch(push(path)),
   resolveUser: () => dispatch(resolveUser()),
-  openModal: (header, content) =>
-    dispatch(openModal(header, content))
+  openModal: (header, content) => dispatch(openModal(header, content))
 });
 
 export const LoginContainer =

--- a/src/routes/reset-password/reset-password-container.js
+++ b/src/routes/reset-password/reset-password-container.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import { ResetPassword } from './reset-password';
+import { push } from 'react-router-redux';
+import { openModal } from 'redux/modules/modal';
+
+const mapDispatchToProps = dispatch => ({
+  push: (path) => dispatch(push(path)),
+  // resolveUser: () => dispatch(resolveUser()),
+  openModal: (header, content) =>
+    dispatch(openModal(header, content))
+});
+
+export const ResetPasswordContainer =
+  connect(
+    null,
+    mapDispatchToProps,
+  )(ResetPassword);

--- a/src/routes/reset-password/reset-password-container.js
+++ b/src/routes/reset-password/reset-password-container.js
@@ -5,7 +5,6 @@ import { openModal } from 'redux/modules/modal';
 
 const mapDispatchToProps = dispatch => ({
   push: (path) => dispatch(push(path)),
-  // resolveUser: () => dispatch(resolveUser()),
   openModal: (header, content) =>
     dispatch(openModal(header, content))
 });

--- a/src/routes/reset-password/reset-password-container.js
+++ b/src/routes/reset-password/reset-password-container.js
@@ -5,8 +5,7 @@ import { openModal } from 'redux/modules/modal';
 
 const mapDispatchToProps = dispatch => ({
   push: (path) => dispatch(push(path)),
-  openModal: (header, content) =>
-    dispatch(openModal(header, content))
+  openModal: (header, content) => dispatch(openModal(header, content))
 });
 
 export const ResetPasswordContainer =

--- a/src/routes/reset-password/reset-password.js
+++ b/src/routes/reset-password/reset-password.js
@@ -9,11 +9,6 @@ export class ResetPassword extends Component {
     push: PropTypes.func.isRequired,
     openModal: PropTypes.func.isRequired,
     match: PropTypes.object.isRequired
-    // match: PropTypes.shape({
-    //   params: {
-    //     nounce: PropTypes.string.isRequired
-    //   }
-    // })
   };
 
   onSubmit = (values) => {

--- a/src/routes/reset-password/reset-password.js
+++ b/src/routes/reset-password/reset-password.js
@@ -22,7 +22,7 @@ export class ResetPassword extends Component {
       .catch((e) => {
         this.props.openModal({
           header: 'Reset password failed!',
-          content: 'Password could not be set'
+          content: 'Password could not be updated'
         });
       });
   }

--- a/src/routes/reset-password/reset-password.js
+++ b/src/routes/reset-password/reset-password.js
@@ -4,22 +4,6 @@ import { Grid } from 'semantic-ui-react';
 import { ResetPasswordForm } from 'components/forms';
 import { userService } from 'api';
 
-function getErrorMessage(response) {
-  if (!response) {
-    return 'Unknown error occured';
-  }
-
-  const { status } = response;
-  switch (status) {
-    case 400:
-      return response.data.error_description;
-    case 404:
-      return 'Page not found';
-    default:
-      return status;
-  }
-};
-
 export class ResetPassword extends Component {
   static propTypes = {
     push: PropTypes.func.isRequired,
@@ -31,7 +15,6 @@ export class ResetPassword extends Component {
     })
   };
 
-  // replace as soon as auth is in place
   onSubmit = (values) => {
     return userService.resetPassword(this.props.match.params.nounce, values.password)
       .then(() => this.props.push('login'))
@@ -39,7 +22,7 @@ export class ResetPassword extends Component {
       .catch((e) => {
         this.props.openModal({
           header: 'Reset password failed!',
-          content: getErrorMessage(e.response)
+          content: 'Password could not be set'
         });
       });
   }

--- a/src/routes/reset-password/reset-password.js
+++ b/src/routes/reset-password/reset-password.js
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from 'semantic-ui-react';
+import { ResetPasswordForm } from 'components/forms';
+import { userService } from 'api';
+
+function getErrorMessage(response) {
+  if (!response) {
+    return 'Unknown error occured';
+  }
+
+  const { status } = response;
+  switch (status) {
+    case 400:
+      return response.data.error_description;
+    case 404:
+      return 'Page not found';
+    default:
+      return status;
+  }
+};
+
+export class ResetPassword extends Component {
+  static propTypes = {
+    push: PropTypes.func.isRequired,
+    openModal: PropTypes.func.isRequired,
+    match: PropTypes.shape({
+      params: {
+        nounce: PropTypes.string.isRequired
+      }
+    })
+  };
+
+  // replace as soon as auth is in place
+  onSubmit = (values) => {
+    return userService.resetPassword(this.props.match.params.nounce, values.password)
+      .then(() => this.props.push('login'))
+      // note, handle error with modal
+      .catch((e) => {
+        this.props.openModal({
+          header: 'Reset password failed!',
+          content: getErrorMessage(e.response)
+        });
+      });
+  }
+
+  render() {
+    return (
+      <Grid
+        textAlign='center'
+        className='reset-password-container'
+        verticalAlign='middle'
+      >
+        <Grid.Column className='center-grid'>
+          <ResetPasswordForm
+            onSubmit={this.onSubmit}
+          />
+        </Grid.Column>
+      </Grid>
+    );
+  }
+}

--- a/src/routes/reset-password/reset-password.js
+++ b/src/routes/reset-password/reset-password.js
@@ -8,11 +8,12 @@ export class ResetPassword extends Component {
   static propTypes = {
     push: PropTypes.func.isRequired,
     openModal: PropTypes.func.isRequired,
-    match: PropTypes.shape({
-      params: {
-        nounce: PropTypes.string.isRequired
-      }
-    })
+    match: PropTypes.object.isRequired
+    // match: PropTypes.shape({
+    //   params: {
+    //     nounce: PropTypes.string.isRequired
+    //   }
+    // })
   };
 
   onSubmit = (values) => {

--- a/src/routes/reset-password/style/reset-password.scss
+++ b/src/routes/reset-password/style/reset-password.scss
@@ -1,0 +1,7 @@
+.reset-password-container {
+  height: 100%;
+}
+
+.center-grid {
+  max-width: 400px;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,10 +1,12 @@
 @import 'base';
 @import '../routes/login/style/login.scss';
 @import '../routes/forgot-password/style/forgot-password.scss';
+@import '../routes/reset-password/style/reset-password.scss';
 @import '../components/footer/style/footer.scss';
 @import '../components/header/style/header.scss';
 @import '../components/navbar/style/navbar.scss';
 @import '../components/modals/style/modal.scss';
+@import '../components/forms/forgot-password-form/style/forgot-password-form.scss';
 
 // Some best-practice CSS that's useful for most apps
 // Just remove them if they're not what you want


### PR DESCRIPTION
added reset-password route
Can only be reached via
staging:3000/reset-password/nounce
later via an email (see #2)

All api addresses are temporary until test server is implemented.

I now distinct between **reset-password** and **forgot-password**. The second is requesting an email with link to reset-password/nounce. The first is the actual place where user _updates to a new chosen password_.

closes #2 